### PR TITLE
feat: open_fish_config command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ supports wsl2(may be few commands not working) and macOS.
 - pwdc  -->  copy the current directory path.
 - reload  -->  just reload the fish shell.
 - copy --> just copy. supports win(wsl) & mac.
+- open_fish_config/ofc --> just open the fish config file.
   
 ## how to install
 ### using fisher

--- a/completions/open_fish_config.fish
+++ b/completions/open_fish_config.fish
@@ -1,0 +1,5 @@
+complete -c reload -s h -l help -x --description "display help message"
+complete -c reload -s c -l cat -x --description "cat or bat fish.config"
+complete -c reload -s c -l path -x --description "echo fish.config path"
+
+

--- a/functions/open_fish_config.fish
+++ b/functions/open_fish_config.fish
@@ -1,0 +1,36 @@
+function open_fish_config
+    argparse -n open_fish_config -x 'c,p,h' \
+        c/cat \
+        p/path \
+        h/help -- $argv
+    or return 1
+
+    set -l help_msg "Description: just open fish config files.
+
+    Usage:
+    open_fish_config [option]
+    open_config [option]
+
+    Options:
+    -h, --help        print this help message.
+    -c, --cat         cat $__fish_config_dir/config.fish
+    -p, --path        echo $__fish_config_dir/config.fish
+    "
+
+    if set -lq _flag_help
+        echo $help_msg
+    else if set -lq _flag_cat
+        if type -q bat
+            bat $__fish_config_dir/config.fish
+        else
+            cat $__fish_config_dir/config.fish
+        end
+    else if set -lq _flag_path
+        echo $__fish_config_dir/config.fish
+    else
+        vim $__fish_config_dir/config.fish
+    end
+end
+
+abbr open_config open_fish_config
+abbr ofc open_fish_config

--- a/functions/reload.fish
+++ b/functions/reload.fish
@@ -1,5 +1,5 @@
 function reload
-    argparse -n bd -x 'c,h' \
+    argparse -n reload -x 'c,h' \
         c/config \
         h/help -- $argv
     or return 1


### PR DESCRIPTION
## open_fish_config
```bash
Description: just open fish config files.

    Usage:
    open_fish_config [option]
    open_config [option]

    Options:
    -h, --help        print this help message.
    -c, --cat          cat $__fish_config_dir/config.fish
    -p, --path       echo $__fish_config_dir/config.fish
```