### PR TITLE
feat: get_os_name command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@ Includes forked commands developed by others.
 supports wsl2(may be few commands not working) and macOS.  
   
 ## command list
-- bd  -->  quickly go back to a parent directory(0rax/fish-bd)
-- pwdc  -->  copy the current directory path.
-- reload  -->  just reload the fish shell.
-- copy --> just copy. supports win(wsl) & mac.
-- open_fish_config/ofc --> just open the fish config file.
-  
+- bd  -->  Quickly go back to a parent directory(0rax/fish-bd)
+- pwdc  -->  Copy the current directory path.
+- reload  -->  Just reload the fish shell.
+- copy --> just copy. Supports win(wsl) & mac.
+- open_fish_config/ofc --> Just open the fish config file.
+- get_os_name --> Returns the name of the OS distribution you are currently using.
+
 ## how to install
 ### using fisher
 ```shell

--- a/functions/get_os_name.fish
+++ b/functions/get_os_name.fish
@@ -1,0 +1,46 @@
+function get_os_name
+    argparse -n open_fish_config -x 'w,h' \
+        w/wsl \
+        h/help -- $argv
+    or return 1
+
+    set -l help_msg "Description: Returns the name of the OS distribution you are currently using.
+
+Usage:
+    get_os_name [option]
+
+Options:
+    -h, --help        print this help message.
+    -w, --wsl         returns whether wsl is used (true or false).
+
+Examples:
+    # When using ArchLinux with WSL.
+    \$ get_os_name
+    > arch
+    \$ get_os_name -w
+    > true
+
+    # When using Ubuntu without WSL.
+    \$ get_os_name
+    > ubuntu
+    \$ get_os_name -w
+    > false
+"
+
+    if set -lq _flag_help
+        echo $help_msg
+    else if set -lq _flag_wsl
+        if [ (string match -r -- "\d*-microsoft-standard-WSL2" (uname -r)) ]
+            echo true
+        else
+            echo false
+        end
+    else
+        for i in (string split ' ' (echo (ls -a /etc/ | grep -E '.*release')))
+            if test $i != 'os-release'; or test $i != 'system-release';
+                echo (string match -r '(.+)(-release)' $i)[2]
+                break
+            end
+        end
+    end
+end

--- a/functions/get_os_name_strict.fish
+++ b/functions/get_os_name_strict.fish
@@ -1,0 +1,30 @@
+function get_os_name_strict
+    if test -e /etc/debian_version; or test -e /etc/debian_release;
+        if test -e /etc/lsb-debian_release
+            echo 'ubuntu'
+        else
+            echo 'debian'
+        end
+    else if test -e /etc/fedora-release
+        echo 'fedora'
+    else if test -e /etc/redhat-release
+        if test -e /etc/oracle-release
+            echo 'oracle'
+        else
+            echo 'redhat'
+        end
+    else if test -e /etc/arch-release
+        echo 'arch'
+    else if test -e /etc/tubolinux-release
+        echo 'turbol'
+    else if test -e /etc/SuSE-release
+        echo 'suse'
+    else if type -e /etc/mandriva-release
+        echo 'mandriva'
+    else if type -e /etc/vine-release
+        echo 'vine'
+    else if test -e /etc/gentoo-release
+        echo 'gentoo'
+    end
+    return 1
+end


### PR DESCRIPTION
## Description
Returns the name of the OS distribution you are currently using.
The OS name is determined based on the information in `/etc/.*-release`

## Usage:
get_os_name [option]

## Options
```
-h, --help        print this help message.
-w, --wsl         returns whether wsl is used (true or false).
```

## Examples
### When using ArchLinux with WSL.
```
$ get_os_name
> arch
$ get_os_name -w
> true
```
### When using Ubuntu without WSL.
```
$ get_os_name
> ubuntu
$ get_os_name -w
> false
```