### PR TITLE
fix: get_os_name; fix to work with ubuntu using lsb_release

### DIFF
--- a/functions/get_os_name.fish
+++ b/functions/get_os_name.fish
@@ -38,8 +38,18 @@ Examples:
     else
         for i in (string split ' ' (echo (ls -a /etc/ | grep -E '.*release')))
             if test $i != 'os-release'; or test $i != 'system-release';
-                echo (string match -r '(.+)(-release)' $i)[2]
-                break
+                switch (echo (string match -r '(.+)(-release)' $i)[2])
+                    case 'lsb' 'debian' 'lsb-debian' 'redhat' 'oracle'
+                        if type -q lsb_release
+                            echo (echo (lsb_release -i) | string match -r '(.+):(.+)')[3] | string trim | string lower
+                            break
+                        else
+                            echo please install lsb-release.
+                            echo Ex: \$ apt-get install lsb-release
+                        end
+                    case *
+                        echo (string match -r '(.+)(-release)' $i)[2]
+                end
             end
         end
     end

--- a/functions/get_os_name_strict.fish
+++ b/functions/get_os_name_strict.fish
@@ -1,6 +1,6 @@
 function get_os_name_strict
     if test -e /etc/debian_version; or test -e /etc/debian_release;
-        if test -e /etc/lsb-debian_release
+        if test -e /etc/lsb-debian-release
             echo 'ubuntu'
         else
             echo 'debian'


### PR DESCRIPTION
### changes
- fix typo in get_os_name_strict
- support ubuntu, debian, redhat and oracle using lsb_release command